### PR TITLE
Chrome issue allows two tabs to acquire the lock.

### DIFF
--- a/browser-test.js
+++ b/browser-test.js
@@ -1,0 +1,159 @@
+const FastMutex = require("./");
+
+const readableTime = (date) => date.toTimeString().split(" ")[0];
+const readableTimeMs = (date) => `${readableTime(date)}.${date.getMilliseconds()}`;
+
+//// Helpers
+let currentRun;
+const addRunLog = (runDate) => {
+  currentRun = document.createElement("details");
+  currentRun.summary = document.createElement("summary");
+  currentRun.summary.innerText = `Run: ${readableTime(runDate)}`;
+  currentRun.setAttribute("open", "open");
+  currentRun.appendChild(currentRun.summary);
+
+  document.body.appendChild(currentRun);
+  currentRun.setAttribute("class", "run");
+};
+const closeRunLog = (pass, summaryText) => {
+  currentRun.setAttribute("class", `run ${pass ? "pass" : "fail"}`);
+  currentRun.summary.innerText += ` - ${summaryText}`;
+  currentRun.removeAttribute("open");
+  currentRun = null;
+};
+const bgColor = (color) => currentRun.style = `background:${color}`;
+
+const log = (...text) => {
+  text = text.join(" ");
+  const div = document.createElement("div");
+  div.innerText = text;
+  if (currentRun) {
+    currentRun.appendChild(div);
+  } else {
+    document.body.appendChild(div);
+  }
+  console.log(text);
+};
+
+const delay = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+
+const resolveAt = (date) => delay(date.getTime() - Date.now()).then(() => date);
+
+// round a date to the next :00/:15/:30/:45
+const roundDateToNext15s = (date) => {
+  date.setMilliseconds(0);
+
+  const s = date.getSeconds();
+
+  if (s < 15) {
+    date.setSeconds(15);
+  } else if (s < 30) {
+    date.setSeconds(30);
+  } else if (s < 45) {
+    date.setSeconds(45);
+  } else {
+    date.setSeconds(0);
+    date.setMinutes(date.getMinutes() + 1);
+  }
+
+  return date;
+};
+
+
+//// Initialisation
+const tabId = "tab-" + Math.floor(Math.random() * 10000);
+log("This is tab: " + tabId);
+
+const counterKey = (runDate) => `${runDate.getTime()}-counter`;
+const setCounter = (runDate, value) => localStorage.setItem(counterKey(runDate), value);
+const getCounter = (runDate) => ~~localStorage.getItem(counterKey(runDate));
+const removeCounter = (runDate) => localStorage.removeItem(counterKey(runDate));
+
+const tabKey = (runDate) => `${runDate.getTime()}-${tabId}`;
+const setTabStarted = (runDate) => localStorage.setItem(tabKey(runDate), "started");
+const setTabCompleted = (runDate) => localStorage.setItem(tabKey(runDate), "completed");
+const getTabKeys = (runDate) => Object.keys(localStorage).filter(k => k.indexOf(`${runDate.getTime()}-tab-`) === 0);
+const waitUntilAllTabsCompleted = (runDate) => {
+  return new Promise((resolve) => {
+    const int = setInterval(() => {
+      const tabs = getTabKeys(runDate);
+      if (tabs.every(t => localStorage.getItem(t) === "completed")) {
+        clearInterval(int);
+        resolve(tabs);
+      }
+    }, 100);
+  });
+};
+
+
+const run = () => {
+  Promise.resolve()
+    .then(() => {
+      const now = new Date();
+      const runDate = roundDateToNext15s(now);
+      addRunLog(runDate);
+      log(`Runid: ${runDate.getTime()}`);
+      log("Run will start at", readableTime(runDate));
+
+      setCounter(runDate, 0);
+
+      return resolveAt(runDate);
+    })
+    .then((runDate) => {
+      log("Started run at", readableTimeMs(new Date()));
+      bgColor("yellow");
+      setTabStarted(runDate);
+
+      return runDate;
+    }).then((runDate) => {
+      const mutex = new FastMutex();
+
+      return mutex.lock("the-lock").then(() => {
+        log("  - Got the lock at", readableTimeMs(new Date()));
+        bgColor("coral");
+        const counterValue = getCounter(runDate);
+        log("  - Got counter value", counterValue);
+
+        return delay(35).then(() => {
+          log("  - Set counter value", counterValue + 1);
+          setCounter(runDate, counterValue + 1)
+        });
+      })
+      .then(() => mutex.release("the-lock"))
+      .then(() => {
+        bgColor("white");
+        log("Finished run at", readableTimeMs(new Date()));
+        setTabCompleted(runDate);
+      })
+      .then(() => {
+        log("Waiting till all tabs finished");
+        return waitUntilAllTabsCompleted(runDate);
+      })
+      .then((tabs) => {
+        const pass = getCounter(runDate) === tabs.length;
+        const passText = pass ? "PASS" : "FAIL";
+        const finalCounter = getCounter(runDate);
+
+        log(passText);
+        log("Final counter value was:", finalCounter);
+        log("Number of tabs in run:", tabs.length);
+        closeRunLog(pass, `${passText} - (${tabs.length} tabs in run, counter was ${finalCounter})`);
+      })
+      .then(() => delay(2000))
+      .then(() => {
+        removeCounter(runDate);
+        getTabKeys(runDate).forEach(k => localStorage.removeItem(k));
+      })
+      .catch((err) => {
+        bgColor("white");
+        setTabCompleted(runDate);
+        log("Failed run with error at", readableTimeMs(new Date()));
+        log("Error:", err);
+        log("FAIL");
+        closeRunLog(false, `FAIL - Error: ${err}`);
+      })
+    })
+    .then(() => run());
+};
+
+run();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,25 @@
+<head>
+  <style>
+    body {
+      font-family: sans-serif;
+    }
+    div {
+    }
+
+    details {
+      margin-bottom: 10px;
+      padding: 5px;
+      border: 1px gray solid;
+    }
+  </style>
+</head>
+<body>
+  <p>Current time: <span class="time"></span></p>
+  <a href="#" target="_blank">Open another tab</a>
+  <script src="./tmp/browser-test.js"></script>
+  <script>
+    setInterval(function () {
+      document.querySelector(".time").innerText = (new Date().toTimeString()).split(" ")[0];
+    }, 500);
+  </script>
+</body>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha test",
-    "build": "mkdir -p dist; $(npm bin)/browserify -t [ babelify --presets [ es2015 ] ] index.js -s FastMutex -o dist/fast-mutex.js && $(npm bin)/uglifyjs dist/fast-mutex.js > dist/fast-mutex.min.js"
+    "build": "mkdir -p dist; $(npm bin)/browserify -t [ babelify --presets [ es2015 ] ] index.js -s FastMutex -o dist/fast-mutex.js && $(npm bin)/uglifyjs dist/fast-mutex.js > dist/fast-mutex.min.js",
+    "build-test-browser": "mkdir -p tmp; $(npm bin)/browserify -t [ babelify --presets [ es2015 ] ] browser-test.js -o tmp/browser-test.js",
+    "test-browser": "npm run build-test-browser && serve -o ."
   },
   "keywords": [
     "mutex",
@@ -22,7 +24,9 @@
     "browserify": "^13.1.0",
     "chai": "^3.5.0",
     "chai-as-promised": "^5.3.0",
+    "mocha": "^3.5.3",
     "node-localstorage": "^1.3.0",
+    "serve": "^6.1.0",
     "sinon": "^1.17.5",
     "uglify-js": "^2.7.3"
   },


### PR DESCRIPTION
I'm not sure that the browser test side of this PR is necessarily ready for merge, but I wanted to share it in it's current state to get a fix for this moving along.

There's a bug in fast-mutex in (at least) chrome, which allows two tabs to obtain the lock at the same time.

Chrome doesn't "commit" localStorage changes to "disk" until the current execution stack has finished. This means in the current sequence:

```
tab one                   |  tab two
setItem("x", "one")       |
                          |  setItem("x", "two")
getItem("x") // => "one"  |
```

tab one will always read "x" as one, even though tab two has changed it.

Inside fast-mutex, this allows two tabs to acquire the lock concurrently. To handle this, we need to separate set and get by a settimeout call.

To demonstrate the issue (and fix) I have created a browser test page. (Run it with `npm run test-browser`)

Open it in two tabs (I would recommend putting the tabs in separate windows side-by-side, otherwise chrome has a tendency to not call timeouts more frequently than 1/per second, which confuses things).

This test triggers synchronous runs every :00/:15/:30/:45 seconds past the minute in each tab. In each tab we acquire a lock, and increment a counter. When all tabs are finished, we should see the counter equal the number of open tabs, otherwise there's been a failure (either two tabs acquired the lock concurrently, or one tab failed to complete).

Here is an example of a run before the fix (in sha 67cc985):

![image](https://user-images.githubusercontent.com/78225/31014269-ddece1ae-a511-11e7-8916-fde8462b5a0e.png)

With two tabs open, both acquire the lock within 1ms of each other.

![image](https://user-images.githubusercontent.com/78225/31014313-17bf27d4-a512-11e7-896f-e056165e1b13.png)
